### PR TITLE
Use property names when reordering

### DIFF
--- a/frontend/src/client/derived.d.ts
+++ b/frontend/src/client/derived.d.ts
@@ -8,8 +8,11 @@ export interface ParsedMDHCollection extends TMDHCollection {
     /** a map from slug to slug-schema */
     propMap: Map<string, TMDHProperty>
 
-    /* the names of all properties */
-    propertyNames: string[]
+    /** a map from slug to names */
+    nameMap: Map<string, string>
+
+    /* the slugs of all properties */
+    propertySlugs: string[]
 
     /** list of the instantiated codecs for this renderer */
     codecMap: Map<string, Codec<any, any>>

--- a/frontend/src/client/index.ts
+++ b/frontend/src/client/index.ts
@@ -63,22 +63,25 @@ export class MDHBackendClient {
     private parseCollection(collection: TMDHCollection): ParsedMDHCollection {
 
         const propMap = new Map<string, TMDHProperty>();
+        const nameMap = new Map<string, string>();
         const codecMap = new Map<string, Codec>();
-        const propertyColumns = new Map<string, TableColumn<TMDHItem<any>>>();
+        const columnMap = new Map<string, TableColumn<TMDHItem<any>>>();
 
-        const propertyNames = collection.properties.map(p => {
+        const propertySlugs = collection.properties.map(p => {
             const { slug, codec } = p;
 
             propMap.set(slug, p);
+            nameMap.set(slug, p.displayName);
 
             const c = this.manager.getWithFallback(codec);
             codecMap.set(slug, c);
-            propertyColumns.set(slug, c.makeReactTableColumn(p));
+            
+            columnMap.set(slug, c.makeReactTableColumn(p));
 
             return p.slug;
         });
 
-        return { propMap, propertyNames, codecMap, columnMap: propertyColumns,  ...collection };
+        return { propMap, nameMap, propertySlugs, codecMap, columnMap,  ...collection };
     }
 
     /** Fetches information about a set of collection items */
@@ -139,7 +142,7 @@ export class MDHBackendClient {
         const propName = (n: string) => (n.startsWith('+') || n.startsWith('-')) ? n.substring(1) : n;
         
         // find all the properties that we want to filter by in the appropriate order
-        return (order || collection.propertyNames)
+        return (order || collection.propertySlugs)
             .filter(n => properties.includes(propName(n))) // filter by queries properties
             .filter(n => collection.propMap.has(propName(n))) // filter by known properties
             .filter(n => collection.codecMap.get(propName(n))!.ordered) // filter by orderable properties

--- a/frontend/src/components/routes/collection/search/index.tsx
+++ b/frontend/src/components/routes/collection/search/index.tsx
@@ -45,7 +45,7 @@ class MDHCollectionSearch extends React.Component<MDHCollectionSearchProps, MDHC
         // restore the default state
         return {
             filters: [],
-            columns: this.props.collection.propertyNames.slice(),
+            columns: this.props.collection.propertySlugs.slice(),
             page: 0,
             per_page: 20,
             widths: undefined,


### PR DESCRIPTION
This PR ensures that the property names instead of their slugs are shown to the user when re-ordering columns. Fixes #17.